### PR TITLE
[QC] Formatting

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,0 +1,12 @@
+name: Format
+
+on: [push, pull_request]
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: axel-op/googlejavaformat-action@v2.0.0
+        with:
+          args: "--replace"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+    - repo: https://github.com/luk-lo/google-style-precommit-hook
+      rev: bd0ad0e38deb889604acfc914a6cc5b2af273127
+      hooks:
+          - id: google-style-java


### PR DESCRIPTION
Add a [pre-commit configuration](https://github.com/luk-lo/google-style-precommit-hook) and a [github action](https://github.com/marketplace/actions/google-java-format) to format java code. Fixes #8 